### PR TITLE
Add comments

### DIFF
--- a/examples/05_comments.lua
+++ b/examples/05_comments.lua
@@ -1,0 +1,32 @@
+local LuASM = require("luasm")
+
+-- 1. Define the instruction set
+local instructions = {
+    LuASM.instruction("mov", {"imm", "reg"}, {}),
+    LuASM.instruction("mov", {"reg", "reg"}, {}),
+    LuASM.instruction("add", {"reg", "reg"}, {}),
+    LuASM.instruction("jmp", {"label"}, {}),
+}
+
+-- 2. Create a runner (use default settings)
+local asm = LuASM:new(instructions, {})
+
+-- 3. Tokenize a source string
+local src = [[
+start:  mov 10 r0  # This is a comment
+        add  r0 r1 ; This is another comment
+        jmp  start
+]]
+local tokenizer = LuASM.string_tokenizer(src)
+
+-- 4. Parse
+local result = asm:parse(tokenizer)
+
+print("Lines parsed:", result.parsed_lines)
+for name, info in pairs(result.labels) do
+    print("Label: " .. name .. " -> line: " .. info.location)
+end
+
+for i, instr in ipairs(result.instructions) do
+    print(i, instr.op)   -- currently just the instruction name
+end

--- a/examples/06_custom_comments.lua
+++ b/examples/06_custom_comments.lua
@@ -1,0 +1,34 @@
+local LuASM = require("luasm")
+
+-- 1. Define the instruction set
+local instructions = {
+    LuASM.instruction("mov", {"imm", "reg"}, {}),
+    LuASM.instruction("mov", {"reg", "reg"}, {}),
+    LuASM.instruction("add", {"reg", "reg"}, {}),
+    LuASM.instruction("jmp", {"label"}, {}),
+}
+
+-- 2. Create a runner (use default settings)
+local asm = LuASM:new(instructions, {
+    comment = "=.*$"
+})
+
+-- 3. Tokenize a source string
+local src = [[
+start:  mov 10 r0    = My custom comment
+        add  r0 r1   = This just works
+        jmp  start
+]]
+local tokenizer = LuASM.string_tokenizer(src)
+
+-- 4. Parse
+local result = asm:parse(tokenizer)
+
+print("Lines parsed:", result.parsed_lines)
+for name, info in pairs(result.labels) do
+    print("Label: " .. name .. " -> line: " .. info.location)
+end
+
+for i, instr in ipairs(result.instructions) do
+    print(i, instr.op)   -- currently just the instruction name
+end

--- a/src/luasm.lua
+++ b/src/luasm.lua
@@ -37,6 +37,7 @@ function LuASM:new(instructions, settings)
     setmetatable(settings, { __index = {
         separator = "[^,%s]+",
         label = "^([%a]+):%s*(.*)",
+        comment = "[;#].*$",
         syntax = {
             imm = "^[%d]+",
             reg = "^%a[%w]*",
@@ -227,6 +228,11 @@ function LuASM:parse(tokenizer)
         parse_data.parsed_lines = parse_data.parsed_lines + 1
 
         if token ~= nil then
+
+            -- Remove comments
+            if self.settings.comment ~= nil then
+                token = token:gsub(self.settings.comment, "")
+            end
 
             --[[
                 This is very basic label processing as labels could be


### PR DESCRIPTION
This pull request add the feature that comments can now be added.

The syntax of the comments can be specified through a setting called `comment`:
```lua
local asm = LuASM:new(instructions, {
    comment = ";.*$"
})
```

This will now allow for comments like this:
```lua
start:  mov 10 r0  ; This is a comment
        add  r0 r1
        jmp  start
```

----

Closes #2 