### PR TITLE
New tokenization system to fix #1

### DIFF
--- a/examples/01_inline_parsing.lua
+++ b/examples/01_inline_parsing.lua
@@ -17,7 +17,7 @@ start:  mov 10 r0
         add  r0 r1
         jmp  start
 ]]
-local tokenizer = LuASM:string_tokenizer(src)
+local tokenizer = asm:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/01_inline_parsing.lua
+++ b/examples/01_inline_parsing.lua
@@ -17,7 +17,7 @@ start:  mov 10 r0
         add  r0 r1
         jmp  start
 ]]
-local tokenizer = LuASM.string_tokenizer(src)
+local tokenizer = LuASM:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/02_file_parsing.lua
+++ b/examples/02_file_parsing.lua
@@ -12,7 +12,7 @@ local instructions = {
 local asm = LuASM:new(instructions, {})
 
 -- 3. Tokenize a source string
-local tokenizer = LuASM.file_tokenizer("./data/02_data.lasm")
+local tokenizer = LuASM:file_tokenizer("./data/02_data.lasm")
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/02_file_parsing.lua
+++ b/examples/02_file_parsing.lua
@@ -12,7 +12,7 @@ local instructions = {
 local asm = LuASM:new(instructions, {})
 
 -- 3. Tokenize a source string
-local tokenizer = LuASM:file_tokenizer("./data/02_data.lasm")
+local tokenizer = asm:file_tokenizer("./data/02_data.lasm")
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/03_custom_arguments.lua
+++ b/examples/03_custom_arguments.lua
@@ -20,7 +20,7 @@ local src = [[
 mov reg0, reg1
 print "Hello"
 ]]
-local tokenizer = LuASM.string_tokenizer(src)
+local tokenizer = LuASM:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/03_custom_arguments.lua
+++ b/examples/03_custom_arguments.lua
@@ -20,7 +20,7 @@ local src = [[
 mov reg0, reg1
 print "Hello"
 ]]
-local tokenizer = LuASM:string_tokenizer(src)
+local tokenizer = asm:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/04_interpreter.lua
+++ b/examples/04_interpreter.lua
@@ -23,7 +23,7 @@ print "Hello"
 print "World"
 print "Message"
 ]]
-local tokenizer = LuASM.string_tokenizer(src)
+local tokenizer = asm:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/05_comments.lua
+++ b/examples/05_comments.lua
@@ -17,7 +17,7 @@ start:  mov 10 r0  # This is a comment
         add  r0 r1 ; This is another comment
         jmp  start
 ]]
-local tokenizer = LuASM.string_tokenizer(src)
+local tokenizer = LuASM:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/05_comments.lua
+++ b/examples/05_comments.lua
@@ -17,7 +17,7 @@ start:  mov 10 r0  # This is a comment
         add  r0 r1 ; This is another comment
         jmp  start
 ]]
-local tokenizer = LuASM:string_tokenizer(src)
+local tokenizer = asm:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/06_custom_comments.lua
+++ b/examples/06_custom_comments.lua
@@ -19,7 +19,7 @@ start:  mov 10 r0    = My custom comment
         add  r0 r1   = This just works
         jmp  start
 ]]
-local tokenizer = LuASM.string_tokenizer(src)
+local tokenizer = LuASM:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/examples/06_custom_comments.lua
+++ b/examples/06_custom_comments.lua
@@ -19,7 +19,7 @@ start:  mov 10 r0    = My custom comment
         add  r0 r1   = This just works
         jmp  start
 ]]
-local tokenizer = LuASM:string_tokenizer(src)
+local tokenizer = asm:string_tokenizer(src)
 
 -- 4. Parse
 local result = asm:parse(tokenizer)

--- a/src/luasm.lua
+++ b/src/luasm.lua
@@ -245,7 +245,7 @@ function LuASM:parse(tokenizer)
             -- LABEL PROCESSING (very basic, one‑label per line)
             -- -------------------------------------------------
             if self.settings.label ~= nil then
-                local label, rest = token:match(self.settings.label)
+                local label, rest = line:match(self.settings.label)
                 if label ~= nil then
                     -- Detect duplicate label definitions.
                     if parse_data.labels[label] ~= nil then
@@ -308,7 +308,7 @@ function LuASM:parse(tokenizer)
 
             ::continue::
         end
-    until token == nil   -- EOF
+    until line == nil   -- EOF
 
     return parse_data, nil
 end

--- a/src/luasm.lua
+++ b/src/luasm.lua
@@ -105,24 +105,29 @@ end
 local Tokenizer = {}
 
 --- Abstract method that must be overridden by a concrete tokenizer.
---- @return string|nil
+--- @return string|nil The next line
 function Tokenizer.get_next_line()
     error("This function has to be implemented!")
     return nil
 end
 
+--- Checks if the parser is at the end of the line
+--- @return boolean If it is at the end of the line
 function Tokenizer:eol()
     return self.line:len() == 0
 end
 
---- @return boolean
+--- Gets the next line and checks if it exist. 
+--- This method moves the tokenizer to the next line.
+--- @return boolean If the next line exists
 function Tokenizer:has_line()
     self.line = self:get_next_line()
 
     return self.line ~= nil
 end
 
---- @return string|nil
+--- Returns the label that is in this line
+--- @return string|nil The label
 function Tokenizer:get_label()
     if self.luasm.settings.label == nil then
         return nil
@@ -138,7 +143,8 @@ function Tokenizer:get_label()
     return label
 end
 
---- @return boolean
+--- Returns the mnemonic of the line
+--- @return string|nil The mnemonic that is being parsed
 function Tokenizer:get_mnemonic()
     local mnemonic, rest = self.line:match(self.luasm.settings.mnemonic)
 
@@ -152,6 +158,9 @@ end
 
 local ArgumentTokenizer = {}
 
+--- Returns the next argument based on the argument type
+--- @param argument_type string The argument type that should be parsed
+--- @return string|nil The parsed result
 function ArgumentTokenizer:get_next(argument_type)
     local argument_regex = self.luasm.settings.syntax[argument_type]
 
@@ -164,6 +173,8 @@ function ArgumentTokenizer:get_next(argument_type)
     return matched
 end
 
+--- Skips the separator part of the line
+--- @return boolean If a separator existed
 function ArgumentTokenizer:skip_separator()
     local matched = self.line:match(self.luasm.settings.separator, self.position)
 
@@ -176,17 +187,20 @@ function ArgumentTokenizer:skip_separator()
     return true
 end
 
+--- Resets the argument tokenizer
 function ArgumentTokenizer:reset()
     self.position = 1
 end
 
+--- Checks if the tokenizer is at the end of the line
+--- @return boolean If the end of line is reached
 function ArgumentTokenizer:eol()
     return self.position > self.line:len()
 end
 
 --- Creates an argument tokenizer based upon the current state
 --- of the creating tokenizer.
---- 
+---
 --- @return table The argument tokenizer
 function Tokenizer:argument_tokenizer()
     local obj = {}

--- a/src/luasm.lua
+++ b/src/luasm.lua
@@ -222,16 +222,16 @@ function LuASM:parse(tokenizer)
         parsed_lines = 0
     }
 
-    local token
+    local line
     repeat
-        token = tokenizer:get_next_line()
+        line = tokenizer:get_next_line()
         parse_data.parsed_lines = parse_data.parsed_lines + 1
 
-        if token ~= nil then
+        if line ~= nil then
 
             -- Remove comments
             if self.settings.comment ~= nil then
-                token = token:gsub(self.settings.comment, "")
+                line = line:gsub(self.settings.comment, "")
             end
 
             --[[
@@ -260,17 +260,17 @@ function LuASM:parse(tokenizer)
                         location = parse_data.parsed_lines
                     }
 
-                    token = trim(rest)
+                    line = trim(rest)
                 end
             end
 
-            local elements = {}
-            string.gsub(token, self.settings.separator,
-                function(value) elements[#elements + 1] = value end)
-
-            if #elements == 0 then
-                goto continue   -- empty line (or comment)
+            if line == "" then
+                goto continue   -- Rest is empty
             end
+
+            local elements = {}
+            string.gsub(line, self.settings.separator,
+                function(value) elements[#elements + 1] = value end)
 
             local errors = {}
             for _, instr in ipairs(self.instructions) do

--- a/src/luasm.lua
+++ b/src/luasm.lua
@@ -104,19 +104,33 @@ end
 local Tokenizer = {}
 
 --- Abstract method that must be overridden by a concrete tokenizer.
+--- @return string|nil
 function Tokenizer.get_next_line()
     error("This function has to be implemented!")
-    return false
+    return nil
 end
 
 --- @return boolean
-function Tokenizer:has_next_line()
-    return false
+function Tokenizer:has_line()
+    self.line = self:get_next_line()
+
+    return self.line ~= nil
 end
 
 --- @return string|nil
 function Tokenizer:get_label()
-    return nil
+    if self.luasm.settings.label == nil then
+        return nil
+    end
+
+    local label, rest = self.line:match(self.settings.label)
+
+    if label ~= nil then
+        self.line   = rest
+        self.cursor = self.cursor + #label
+    end
+
+    return label
 end
 
 --- Creates a new tokenizer without a specific implementation.
@@ -179,27 +193,6 @@ function LuASM:string_tokenizer(input)
         tokenizer.current_line = tokenizer.current_line + 1
 
         return line
-    end
-
-    tokenizer.has_line = function()
-        tokenizer.line = tokenizer.get_next_line()
-
-        return tokenizer.line ~= nil
-    end
-
-    tokenizer.get_label = function()
-        if self.settings.label == nil then
-            return nil
-        end
-
-        local label, rest = tokenizer.line:match(self.settings.label)
-
-        if label ~= nil then
-            tokenizer.line   = rest
-            tokenizer.cursor = tokenizer.cursor + #label
-        end
-
-        return label
     end
 
     return tokenizer

--- a/src/luasm.lua
+++ b/src/luasm.lua
@@ -117,7 +117,7 @@ function Tokenizer:eol()
     return self.line:len() == 0
 end
 
---- Gets the next line and checks if it exist. 
+--- Gets the next line and checks if it exist.
 --- This method moves the tokenizer to the next line.
 --- @return boolean If the next line exists
 function Tokenizer:has_line()


### PR DESCRIPTION
As stated in #1 it is currently not possible to create an instruction with a syntax like this:

```asm
print out "Hello World"
```

These changes in this pull request will change this.

This means that this pull request will fix #1.